### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: '0 7 * * *'  # Every day at 07:00 UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref}}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build
+        uses: esphome/build-action@v7
+        with:
+          yaml-file: test_empty_components.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,14 @@ concurrency:
 
 jobs:
   build:
+    name: ${{ matrix.esphome-version }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        esphome-version:
+          - stable
+          - beta
+          - dev
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -22,4 +29,5 @@ jobs:
       - name: Build
         uses: esphome/build-action@v7
         with:
+          version: ${{ matrix.esphome-version }}
           yaml-file: test_empty_components.yaml


### PR DESCRIPTION
Running a daily CI (as well as PRs and push to main) will allow us to be notified if ESPHome dev gets any breaking changes that affects these components.