### PR TITLE
Fix empty_automation codegen for TemplatableFn change

### DIFF
--- a/components/empty_automation/__init__.py
+++ b/components/empty_automation/__init__.py
@@ -60,7 +60,8 @@ EMPTY_AUTOMATION_CONDITION_SCHEMA = automation.maybe_simple_id(
 async def empty_automation_set_state_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    cg.add(var.set_state(config[CONF_STATE]))
+    templ = await cg.templatable(config[CONF_STATE], args, cg.bool_)
+    cg.add(var.set_state(templ))
     return var
 
 


### PR DESCRIPTION
## Summary
- ESPHome dev replaced `TemplatableValue` with `TemplatableFn` (function-pointer-only storage) for trivially copyable `TEMPLATABLE_VALUE` types
- The `empty_automation` action codegen passed a raw `bool` to `set_state()`, which `TemplatableFn<bool>` can't accept via `operator=`
- Use `cg.templatable()` to wrap the constant in a stateless lambda, matching the new codegen pattern

## Test plan
- [ ] CI build against ESPHome dev passes