### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary

Adds a Dependabot configuration that watches the GitHub Actions ecosystem and opens weekly update PRs. This keeps the workflows' pinned action SHAs current without manual chasing.