### PR TITLE
Add minimum permissions to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref}}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: ${{ matrix.esphome-version }}

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -13,6 +13,9 @@ on:
       - "**.yaml"
       - "**.yml"
 
+permissions:
+  contents: read
+
 jobs:
   yamllint:
     name: yamllint


### PR DESCRIPTION
Adds a top-level `permissions: contents: read` block to both CI workflows so each job runs with the minimum scope required (read-only checkout). This follows GitHub's hardening guidance for least-privilege workflow tokens.